### PR TITLE
Update URL to GZip archive

### DIFF
--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -9,6 +9,6 @@ entries:
     name: helm
     type: application
     urls:
-    - https://github.com/stolostron/grc-e2e-policy-generator-test/raw/main/helm/
+    - https://github.com/stolostron/grc-e2e-policy-generator-test/raw/main/helm/helm-0.1.0.tgz
     version: 0.1.0
 generated: "2024-02-08T15:55:49.744539-05:00"


### PR DESCRIPTION
Turns out `helm` uses `urls` to pull the GZip file, so it needs to be specified directly.